### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This application embeds the C yaml parser "[libyaml](http://pyyaml.org/wiki/LibY
  
 # Example
 
-###The yaml file...
+### The yaml file...
 
     # demo1.yaml
     ---
@@ -54,7 +54,7 @@ This application embeds the C yaml parser "[libyaml](http://pyyaml.org/wiki/LibY
 
 
 
-###Load command...
+### Load command...
 
 	3> yaml:load_file("test/yaml/demo1.yaml", [implicit_atoms]).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
